### PR TITLE
fix: resolve CVE-2026-26996 in minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
     "tests/*"
   ],
   "dependencies": {},
+  "pnpm": {
+    "overrides": {
+      "minimatch@<3.1.3": "^3.1.3",
+      "minimatch@>=9.0.0 <9.0.6": "^9.0.6"
+    }
+  },
   "resolutions": {
     "@testing-library/dom>@babel/runtime": "^7.26.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@testing-library/dom>@babel/runtime': ^7.26.10
+  minimatch@<3.1.3: ^3.1.3
+  minimatch@>=9.0.0 <9.0.6: ^9.0.6
 
 importers:
 
@@ -2579,14 +2581,11 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -4346,7 +4345,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.3
+      minimatch: 9.0.9
       semver: 7.7.4
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
@@ -5209,7 +5208,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -5891,15 +5890,11 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@9.0.3:
+  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-26996 in `minimatch`.

**Advisory**: minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern
**Vulnerable versions**: <3.1.3
**Patched versions**: >=3.1.3
**Advisory URL**: https://github.com/advisories/GHSA-3ppc-4f35-3m26

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-26996: _minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-26996 is no longer reported