### PR TITLE
fix: resolve CVE-2026-33671 in picomatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   "pnpm": {
     "overrides": {
       "minimatch@<3.1.3": "^3.1.3",
-      "minimatch@>=9.0.0 <9.0.6": "^9.0.6"
+      "minimatch@>=9.0.0 <9.0.6": "^9.0.6",
+      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4"
     }
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@testing-library/dom>@babel/runtime': ^7.26.10
   minimatch@<3.1.3: ^3.1.3
   minimatch@>=9.0.0 <9.0.6: ^9.0.6
+  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
 
 importers:
 
@@ -2062,7 +2063,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2716,10 +2717,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -6023,8 +6020,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.2: {}
-
   picomatch@4.0.4: {}
 
   pluralize@8.0.0: {}
@@ -6726,7 +6721,7 @@ snapshots:
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
-      picomatch: 4.0.2
+      picomatch: 4.0.4
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-33671 in `picomatch`.

**Advisory**: Picomatch has a ReDoS vulnerability via extglob quantifiers
**Vulnerable versions**: >=4.0.0 <4.0.4
**Patched versions**: >=4.0.4
**Advisory URL**: https://github.com/advisories/GHSA-c2c7-rcm5-vvqj

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33671: _Picomatch has a ReDoS vulnerability via extglob quantifiers_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33671 is no longer reported